### PR TITLE
Use cell `vector_text` to color by other columns

### DIFF
--- a/hips_server/tcga/api.py
+++ b/hips_server/tcga/api.py
@@ -3,6 +3,8 @@ from ninja.pagination import paginate
 from typing import List
 from .models import Image, Cell
 
+from tcga.constants import VECTOR_COLUMNS
+
 
 api = NinjaAPI()
 
@@ -21,6 +23,7 @@ class CellSchema(Schema):
     height: float
     orientation: float
     classification: str
+    vector_text: str
 
 
 @api.get("/images", response=List[ImageSchema])
@@ -32,3 +35,8 @@ def images(request):
 @paginate()
 def cells(request, image_id):
     return Cell.objects.filter(image__id=image_id)
+
+
+@api.get("/cells/columns")
+def cell_columns(request):
+    return VECTOR_COLUMNS

--- a/hips_viewer/src/ColorOptions.vue
+++ b/hips_viewer/src/ColorOptions.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue';
+import { ref, computed } from 'vue';
 import colorbrewer from 'colorbrewer';
 import {
-    selectedColor, colorBy, attributeOptions, colormapName
+    selectedColor, colorBy, attributeOptions, colormapName, colormapType
 } from '@/store';
 
 interface TreeItem {
@@ -12,9 +12,6 @@ interface TreeItem {
 }
 
 const showPicker = ref(false)
-const colormapType = ref<
-    'qualitative' | 'sequential' | 'diverging'
->('qualitative')
 const nestedAttributeOptions = computed(() => {
     const nested: TreeItem[] = []
     attributeOptions.value.forEach((attrName: string) => {
@@ -40,7 +37,6 @@ function select(selected: any) {
     }
 }
 
-watch(colormapType, () => colormapName.value = undefined)
 </script>
 
 <template>

--- a/hips_viewer/src/ColorOptions.vue
+++ b/hips_viewer/src/ColorOptions.vue
@@ -12,6 +12,7 @@ interface TreeItem {
 }
 
 const showPicker = ref(false)
+const attrSelection = ref()
 const nestedAttributeOptions = computed(() => {
     const nested: TreeItem[] = []
     attributeOptions.value.forEach((attrName: string) => {
@@ -33,6 +34,7 @@ const nestedAttributeOptions = computed(() => {
 
 function select(selected: any) {
     if (selected.length) {
+        if (attrSelection.value) attrSelection.value.blur()
         colorBy.value = selected[0]
     }
 }
@@ -60,6 +62,7 @@ function select(selected: any) {
             ></v-color-picker>
             <v-label>All Other Cells</v-label>
             <v-select
+                ref="attrSelection"
                 :model-value="colorBy"
                 label="Color By Attribute"
                 density="compact"

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -8,9 +8,8 @@ import {
     cellDrawerHeight, cellDrawerResizing,
     tooltipEnabled, tooltipContent, tooltipPosition,
     colormapName, map, fetchProgress,
-    attributeOptions,
-    cellColumns,
-    colorBy
+    attributeOptions, cellColumns,
+    colorBy, colorLegend
 } from '@/store';
 
 import CellDrawer from '@/CellDrawer.vue';
@@ -29,6 +28,10 @@ const defaultAttributes = [
 ]
 const tooltipExclude = ['id', 'vector_text']
 const mapId = computed(() => 'map-' + props.id)
+const colorLegendShown = computed(() =>
+    cells.value && colorBy.value && colormapName.value &&
+    colorLegend.value && colorLegend.value.categories().length
+)
 
 function init() {
     createMap(mapId.value, props.image.tile_url).then(() => {
@@ -54,7 +57,7 @@ function drawCells() {
         cellFeature.value.data(cells.value).draw()
         pointFeature.value.data(cells.value).draw()
         updateColors()
-        cellDrawerHeight.value = 100;
+        cellDrawerHeight.value = 80;
         status.value = undefined;
     }
 }
@@ -94,7 +97,7 @@ watch(colormapName, () => {
         @mousemove="resizeCellDrawer"
     >
         <div :id="mapId" class="map" :style="{height: `calc(100% - ${cellDrawerHeight + 70}px) !important`}"></div>
-        <div class="status" :style="{bottom: cellDrawerHeight + 80 + 'px'}">
+        <div class="status" :style="{bottom: cellDrawerHeight + (colorLegendShown ? 180 : 80) + 'px'}">
             <v-card v-if="status" class="px-4 py-2">
                 {{ status }}
                 <v-progress-linear v-if="fetchProgress" :model-value="fetchProgress"></v-progress-linear>

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -120,7 +120,7 @@ watch(colormapName, () => {
         <div v-if="cells" class="actions">
             <v-btn icon>
                 <span class="material-symbols-outlined">palette</span>
-                <v-menu activator="parent" location="end" open-on-hover :close-on-content-click="false">
+                <v-menu activator="parent" location="end" :close-on-content-click="false">
                     <ColorOptions />
                 </v-menu>
             </v-btn>

--- a/hips_viewer/src/api.ts
+++ b/hips_viewer/src/api.ts
@@ -44,3 +44,8 @@ export async function fetchImageCells(imageId: number) {
   await new Promise(r => setTimeout(r, 150));
   return results
 }
+
+export async function fetchCellColumns() {
+  const url = `${baseURL}/cells/columns`
+  return await cachedFetch(url, 'cell-data-cache')
+}

--- a/hips_viewer/src/map.ts
+++ b/hips_viewer/src/map.ts
@@ -5,7 +5,7 @@ import {
     cells, map, maxZoom, cellFeature, pointFeature,
     colorBy, colormapName, colorLegend,
 } from '@/store'
-import { clusterFirstPoint, colorInterpolate, hexToRgb } from './utils';
+import { clusterFirstPoint, colorInterpolate, getCellAttribute, hexToRgb } from './utils';
 
 
 export async function createMap(mapId: string, tileUrl: string) {
@@ -65,9 +65,9 @@ export function addHoverCallback(callback: Function, feature: any) {
 
 export function updateColors() {
     if (colormapName.value && colorBy.value && cells.value && colorLegend.value) {
-        // TODO: update this for other columns
-        // This only works for columns saved as fields
-        const values = [...new Set(cells.value.map((cell: any) => cell[colorBy.value]))]
+        const values = [...new Set(cells.value.map(
+            (cell: any) => getCellAttribute(cell, colorBy.value)
+        ))]
         // @ts-ignore
         const colormapSets = colorbrewer[colormapName.value]
         let colors = colormapSets[values.length];
@@ -84,7 +84,7 @@ export function updateColors() {
                 domain: range,
                 colors,
             }])
-            colormapFunction = (v: number) => {
+            colormapFunction = (v: any) => {
                 const valueProportion = (v - range[0]) / (range[1] - range[0])
                 const maxIndex = rgbColors.length - 1
                 if (valueProportion === 1) return rgbColors[maxIndex]
@@ -120,7 +120,9 @@ export function updateColors() {
                 if (cell.__cluster) {
                     cell = clusterFirstPoint(cells.value, cell, i)
                 }
-                return colormapFunction(cell[colorBy.value])
+                const value = getCellAttribute(cell, colorBy.value)
+                if (!value) return {r:0, g:0, b:0}
+                return colormapFunction(value)
             }
             cellFeature.value.style('strokeColor', styleCellFunction).draw()
             pointFeature.value.style('fillColor', styleCellFunction).draw()

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -22,9 +22,13 @@ export const tooltipPosition = ref()
 export const colorLegend = ref()
 export const selectedColor = ref('#0f0')
 export const colorBy = ref('classification')
+export const colormapType = ref<
+    'qualitative' | 'sequential' | 'diverging'
+>('qualitative')
 export const colormapName = ref<string | undefined>('Paired')
 export const attributeOptions = ref()
 
 
 // Store watchers
+watch(colormapType, () => colormapName.value = undefined)
 watch([selectedColor, colorBy, colormapName], updateColors)

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -31,4 +31,10 @@ export const attributeOptions = ref()
 
 // Store watchers
 watch(colormapType, () => colormapName.value = undefined)
-watch([selectedColor, colorBy, colormapName], updateColors)
+watch([selectedColor, colorBy, colormapName], () => {
+    status.value = 'Updating colors...'
+    setTimeout(() => {
+        updateColors()
+        status.value = undefined
+    }, 1)
+})

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -9,12 +9,13 @@ export const status = ref();
 export const fetchProgress = ref(0);
 
 export const cells = ref();
+export const cellColumns = ref();
 export const cellFeature = ref()
 export const pointFeature = ref()
 export const cellDrawerHeight = ref(0);
 export const cellDrawerResizing = ref(false)
 
-export const tooltipEnabled = ref(true)
+export const tooltipEnabled = ref(false)
 export const tooltipContent = ref()
 export const tooltipPosition = ref()
 
@@ -22,9 +23,7 @@ export const colorLegend = ref()
 export const selectedColor = ref('#0f0')
 export const colorBy = ref('classification')
 export const colormapName = ref<string | undefined>('Paired')
-export const attributeOptions = ref([
-    'classification', 'orientation', 'width', 'height', 'x', 'y'
-])
+export const attributeOptions = ref()
 
 
 // Store watchers

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -10,6 +10,8 @@ export interface Cell  {
     width: number;
     height: number;
     orientation: number;
+    vector_text?: string;
+    [vector_column: string]: string | number | undefined;
 }
 
 export interface Thumbnail {

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -1,3 +1,6 @@
+import { cellColumns } from "./store";
+import type { Cell } from "./types";
+
 interface RGB {r: number, g: number, b: number}
 
 // from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
@@ -40,4 +43,18 @@ export function clusterFirstPoint (data: any, d: any, i: number) {
     return data[d._points[0].index];
   }
   return clusterFirstPoint(data, d._clusters[0], i);
+}
+
+export function getCellAttribute(cell: Cell, attrName: string) {
+  if (cell[attrName]) return cell[attrName]
+  else if (cellColumns.value && cell.vector_text) {
+    const index = cellColumns.value.indexOf(attrName)
+    const vector = cell.vector_text.split(',')
+    if (index >=0 && vector && vector[index]) {
+      const value = vector[index]
+      if (parseFloat(value)) return parseFloat(value)
+      return value
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
As a follow-up to #1, this PR allows the user to color by other cell attributes that are found in the cell's `vector_text` column. To interpret the comma-separated string contents of `vector_text`, we must fetch a list of the column names from the server (this is assumed to have the same order as the `vector_text` contents).

With the addition of these other columns, the "color by attribute" selection has a lot of options, so we group attributes if they have the same first component of their names (where attribute name components are separated by `.`)
