### PR TITLE
Fix bug in getCellAttribute

### DIFF
--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -52,7 +52,7 @@ export function getCellAttribute(cell: Cell, attrName: string) {
     const vector = cell.vector_text.split(',')
     if (index >=0 && vector && vector[index]) {
       const value = vector[index]
-      if (parseFloat(value)) return parseFloat(value)
+      if (!isNaN(parseFloat(value))) return parseFloat(value)
       return value
     }
   }


### PR DESCRIPTION
```
      if (parseFloat(value)) ...
```
fails if `value = "0.0"`. The change corrects this