### PR TITLE
Upgrade geojs

### DIFF
--- a/hips_viewer/package-lock.json
+++ b/hips_viewer/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource/roboto": "5.2.5",
         "@mdi/font": "7.4.47",
         "colorbrewer": "^1.6.1",
-        "geojs": "^1.14.10",
+        "geojs": "^1.14.12",
         "vue": "^3.5.13",
         "vuetify": "^3.8.1"
       },
@@ -4495,9 +4495,9 @@
       }
     },
     "node_modules/geojs": {
-      "version": "1.14.10",
-      "resolved": "https://registry.npmjs.org/geojs/-/geojs-1.14.10.tgz",
-      "integrity": "sha512-wsxLnfr9w+tj8AIn3x5yRzHZVn+X3IyUFwRSWLsbpjnnq3rwu/E02H9tExCthfZa4BUuPiENUl+QwPcGPKVSjQ==",
+      "version": "1.14.12",
+      "resolved": "https://registry.npmjs.org/geojs/-/geojs-1.14.12.tgz",
+      "integrity": "sha512-mBQJr5fMFHJQvcgdbciiGh/dmHUYgOMrzTRiK3gBb8v3GDy098KXAdeAvuY9SIWyKx2jUcaeci/nz9VdD5KEyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "canvas": "^3.0.0",

--- a/hips_viewer/package.json
+++ b/hips_viewer/package.json
@@ -14,7 +14,7 @@
     "@fontsource/roboto": "5.2.5",
     "@mdi/font": "7.4.47",
     "colorbrewer": "^1.6.1",
-    "geojs": "^1.14.10",
+    "geojs": "^1.14.12",
     "vue": "^3.5.13",
     "vuetify": "^3.8.1"
   },


### PR DESCRIPTION
This PR bumps the version of geojs from `1.14.10` to `1.14.12` for improved performance when switching between clustered points and individual cell ellipses.