### PR TITLE
Select cells by clicking histogram

### DIFF
--- a/hips_viewer/src/CellDistribution.vue
+++ b/hips_viewer/src/CellDistribution.vue
@@ -11,6 +11,7 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
 
 const chartOptions = { responsive: true }
 
+const viewportCalculated = ref(false)
 const histNumBucketsSlider = ref(histNumBuckets.value)
 
 const debouncedUpdateHistBuckets = (n: number) => {
@@ -29,6 +30,7 @@ function changeHistSelection() {
   }
   else if (histSelectionType.value === 'viewport') {
     histCellIds.value = new Set(cellFeature.value.polygonSearch(map.value.corners()).found.map((c: any) => c.id))
+    viewportCalculated.value = true
   }
   else if (histSelectionType.value === 'selected') {
     histCellIds.value = new Set(selectedCellIds.value)
@@ -36,10 +38,10 @@ function changeHistSelection() {
 }
 
 watchEffect(async () => {
-  if (chartData.value) return
+  const notCalculated = histSelectionType.value === 'viewport' && !viewportCalculated.value
+  if (chartData.value && !notCalculated) return
 
   await new Promise(r => setTimeout(r, 100)) // wait for DOM update
-  cellData.value = cellDistribution()
   changeHistSelection()
 })
 

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -33,7 +33,11 @@ export const histNumBuckets = ref(50)
 export const histCellIds = ref<Set<number>>(new Set<number>())
 export const histSelectionType = ref<'all' | 'viewport' | 'selected'>('all')
 export const histogramScale = ref<'linear' | 'log'>('linear')
-export const cellData = ref<null | { key: string | number, color: string, count: number }[]>(null)
+export const cellData = ref<null | {
+  key: string
+  color: string
+  cellIds: Set<number>
+  count: number }[]>(null)
 export const chartData = ref()
 
 export const colorLegend = ref()


### PR DESCRIPTION
This PR adds the ability to select cells from the `CellDistribution` card.
<img width="1500" height="1002" alt="image" src="https://github.com/user-attachments/assets/01dac845-948a-41b9-9336-b26cf61143ad" />

<img width="1498" height="1009" alt="image" src="https://github.com/user-attachments/assets/ede55833-632e-453b-a644-6501247c2024" />

Ctrl/shift clicking works for selecting multiple bars.

<img width="1513" height="1021" alt="image" src="https://github.com/user-attachments/assets/ef219bc0-e627-43b1-baf5-15c58525dca6" />

The cell selection also respects the viewport if `histSelectionType === 'viewport'`