### PR TITLE
Add a toggle to filter by selected

### DIFF
--- a/hips_viewer/src/FilterMenu.vue
+++ b/hips_viewer/src/FilterMenu.vue
@@ -12,6 +12,7 @@ import AttributeSelect from './AttributeSelect.vue'
 
 const addMode = ref<boolean>(false)
 const addAttribute = ref<string | undefined>()
+const population = ref<'all' | 'selected'>('all')
 const msg = ref<string | undefined>()
 
 const shownFilterOptions = computed(
@@ -19,17 +20,17 @@ const shownFilterOptions = computed(
 )
 
 function selectCells() {
-  msg.value = 'Searching...'
+  msg.value = `Searching among ${population.value} cells...`
   setTimeout(() => {
-    selectedCellIds.value = new Set(getFilterMatchIds())
+    selectedCellIds.value = new Set(getFilterMatchIds(population.value === 'selected'))
     msg.value = selectedCellIds.value.size + ' matched cells'
   }, 100)
 }
 
 function filterCells() {
-  msg.value = 'Searching...'
+  msg.value = `Searching among ${population.value} cells...`
   setTimeout(() => {
-    filterMatchCellIds.value = new Set(getFilterMatchIds())
+    filterMatchCellIds.value = new Set(getFilterMatchIds(population.value === 'selected'))
     msg.value = filterMatchCellIds.value.size + ' matched cells'
   }, 100)
 }
@@ -92,6 +93,24 @@ watch([currentFilters, addAttribute], () => {
     </div>
     <v-card-text>
       <table width="500">
+        <tr>
+          <td>Population</td>
+          <td>
+            <v-btn-toggle
+              v-model="population"
+              variant="outlined"
+              class="short-btn-toggle"
+              mandatory
+            >
+              <v-btn value="all">
+                All Cells
+              </v-btn>
+              <v-btn value="selected">
+                Selected Only
+              </v-btn>
+            </v-btn-toggle>
+          </td>
+        </tr>
         <tr
           v-for="filter in shownFilterOptions"
           :key="filter.label"
@@ -192,11 +211,7 @@ watch([currentFilters, addAttribute], () => {
           Cancel
         </v-btn>
       </div>
-      <div class="centered-row">
-        <v-label v-if="msg">
-          {{ msg }}
-        </v-label>
-      </div>
+      <v-divider thickness="2" />
       <div class="centered-row">
         <v-btn
           @click="resetCurrentFilters"
@@ -216,6 +231,11 @@ watch([currentFilters, addAttribute], () => {
           Filter cells
         </v-btn>
       </div>
+      <div class="centered-row">
+        <v-label v-if="msg">
+          {{ msg }}
+        </v-label>
+      </div>
     </v-card-text>
   </v-card>
 </template>
@@ -225,10 +245,18 @@ watch([currentFilters, addAttribute], () => {
   display: flex;
   justify-content: center;
   column-gap: 15px;
-  margin-bottom: 10px;
+  padding: 4px;
 }
 .filter-range-slider .v-field__input {
   padding: 0px 0px 0px 5px;
   min-height: 30px;
+}
+.short-btn-toggle {
+  width: 100%;
+  height: 30px !important;
+}
+.short-btn-toggle .v-btn {
+  height: 30px !important;
+  width: 50%
 }
 </style>

--- a/hips_viewer/src/FilterMenu.vue
+++ b/hips_viewer/src/FilterMenu.vue
@@ -6,13 +6,13 @@ import {
   selectedCellIds,
   filterMatchCellIds,
   hiddenFilters,
+  filterPopulation,
 } from './store'
 import { addFilterOption, getFilterMatchIds, resetCurrentFilters } from './utils'
 import AttributeSelect from './AttributeSelect.vue'
 
 const addMode = ref<boolean>(false)
 const addAttribute = ref<string | undefined>()
-const population = ref<'all' | 'selected'>('all')
 const msg = ref<string | undefined>()
 
 const shownFilterOptions = computed(
@@ -20,17 +20,17 @@ const shownFilterOptions = computed(
 )
 
 function selectCells() {
-  msg.value = `Searching among ${population.value} cells...`
+  msg.value = `Searching among ${filterPopulation.value} cells...`
   setTimeout(() => {
-    selectedCellIds.value = new Set(getFilterMatchIds(population.value === 'selected'))
+    selectedCellIds.value = new Set(getFilterMatchIds(filterPopulation.value === 'selected'))
     msg.value = selectedCellIds.value.size + ' matched cells'
   }, 100)
 }
 
 function filterCells() {
-  msg.value = `Searching among ${population.value} cells...`
+  msg.value = `Searching among ${filterPopulation.value} cells...`
   setTimeout(() => {
-    filterMatchCellIds.value = new Set(getFilterMatchIds(population.value === 'selected'))
+    filterMatchCellIds.value = new Set(getFilterMatchIds(filterPopulation.value === 'selected'))
     msg.value = filterMatchCellIds.value.size + ' matched cells'
   }, 100)
 }
@@ -94,10 +94,10 @@ watch([currentFilters, addAttribute], () => {
     <v-card-text>
       <table width="500">
         <tr>
-          <td>Population</td>
+          <td>filterPopulation</td>
           <td>
             <v-btn-toggle
-              v-model="population"
+              v-model="filterPopulation"
               variant="outlined"
               class="short-btn-toggle"
               mandatory

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -64,6 +64,7 @@ export const filterOptions = ref<FilterOption[]>()
 export const filterVectorIndices = ref<Record<string, number>>({})
 export const currentFilters = ref<Record<string, (string | number)[]>>({})
 export const hiddenFilters = ref<Set<string>>(new Set())
+export const filterPopulation = ref<'all' | 'selected'>('all')
 export const filterMatchCellIds = ref<Set<number>>(new Set<number>())
 
 // Store watchers

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -225,8 +225,9 @@ export function addFilterOption(attr: string) {
   }
 }
 
-export function getFilterMatchIds() {
+export function getFilterMatchIds(selectedOnly: boolean) {
   return cells.value.filter((cell: Cell) => {
+    if (selectedOnly && !selectedCellIds.value.has(cell.id)) return false
     for (const key in currentFilters.value) {
       const filterValue = currentFilters.value[key]
       let vectorIndex = cellColumns.value.indexOf(key)


### PR DESCRIPTION
This PR adds a toggle to the filter menu that allows a user to set the population of cells to filter on. By default, the filter menu will filter all cells, and the user may switch this toggle to limit the filter to selected cells only. This PR also makes a minor update to the layout of the filter menu.

<img width="1348" height="1086" alt="image" src="https://github.com/user-attachments/assets/22198c5a-2ea7-4279-9633-a27b5eeb2d94" />
