### PR TITLE
Colormap Selection Component

### DIFF
--- a/hips_viewer/package-lock.json
+++ b/hips_viewer/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@fontsource/roboto": "5.2.5",
         "@mdi/font": "7.4.47",
-        "colorbrewer": "^1.6.1",
+        "@types/d3-scale-chromatic": "^3.1.0",
+        "d3-scale-chromatic": "^3.1.0",
         "geojs": "^1.14.12",
         "vue": "^3.5.13",
         "vue-chartjs": "^5.3.2",
@@ -2906,6 +2907,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4173,12 +4180,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/colorbrewer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.6.1.tgz",
-      "integrity": "sha512-x3N8Hco/evYxb+Qf6D2yvA7T9jXQIMmxQmTzZ0Hhd2JklsL5iWn+nWdvFT1zytYFXvnDwTpWml5NceGUFWqtPg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/colorjs.io": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
@@ -4390,7 +4391,6 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -4547,7 +4547,6 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -4617,7 +4616,6 @@
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"

--- a/hips_viewer/package.json
+++ b/hips_viewer/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@fontsource/roboto": "5.2.5",
     "@mdi/font": "7.4.47",
-    "colorbrewer": "^1.6.1",
+    "@types/d3-scale-chromatic": "^3.1.0",
+    "d3-scale-chromatic": "^3.1.0",
     "geojs": "^1.14.12",
     "vue": "^3.5.13",
     "vue-chartjs": "^5.3.2",

--- a/hips_viewer/src/CellDrawer.vue
+++ b/hips_viewer/src/CellDrawer.vue
@@ -17,9 +17,16 @@ const filteredThumbnails = computed(() => {
     return !filterMatchCellIds.value.size || filterMatchCellIds.value.has(t.id)
   })
 })
-const hexCellColors = computed(() => Object.fromEntries(
-  Object.entries(cellColors.value).map(([cellId, rgbColor]) => [cellId, rgbToHex(rgbColor as RGB)]),
-))
+const hexCellColors = computed(() => {
+  if (!cellColors.value) {
+    return Object.fromEntries(
+      thumbnails.value.map((t: Thumbnail) => [t.id, '#000']),
+    )
+  }
+  return Object.fromEntries(
+    Object.entries(cellColors.value).map(([cellId, rgbColor]) => [cellId, rgbToHex(rgbColor as RGB)]),
+  )
+})
 
 function loadThumbnails({ done }: any) {
   if (props.cells.length === thumbnails.value.length) done('empty')
@@ -67,9 +74,9 @@ function loadThumbnails({ done }: any) {
         :style="`border-color:${
           selectedCellIds.has(thumbnail.id) ? selectedColor: hexCellColors[thumbnail.id]
         };border-width:${
-          cellColors[thumbnail.id] ? 4 : 0
+          hexCellColors[thumbnail.id] ? 4 : 0
         }px;padding:${
-          cellColors[thumbnail.id] ? 0 : 4
+          hexCellColors[thumbnail.id] ? 0 : 4
         }px`"
         class="cell-thumbnail"
         @click="(e) => clickCellThumbnail(e, thumbnail.id)"

--- a/hips_viewer/src/CellDrawer.vue
+++ b/hips_viewer/src/CellDrawer.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { Cell, Thumbnail } from '@/types'
+import type { Cell, RGB, Thumbnail } from '@/types'
 import { cellColors, filterMatchCellIds, selectedCellIds, selectedColor } from './store'
-import { clickCellThumbnail, rgbToHex, type RGB } from './utils'
+import { clickCellThumbnail, rgbToHex } from './utils'
 
 const props = defineProps<{
   cells: Cell[]
@@ -24,7 +24,10 @@ const hexCellColors = computed(() => {
     )
   }
   return Object.fromEntries(
-    Object.entries(cellColors.value).map(([cellId, rgbColor]) => [cellId, rgbToHex(rgbColor as RGB)]),
+    Object.entries(cellColors.value).map(([cellId, rgbColor]) => {
+      if (rgbColor) return [cellId, rgbToHex(rgbColor as RGB)]
+      return [cellId, 'transparent']
+    }),
   )
 })
 

--- a/hips_viewer/src/ColorOptions.vue
+++ b/hips_viewer/src/ColorOptions.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import colorbrewer from 'colorbrewer'
 import {
   selectedColor, colorBy,
-  colormapName, colormapType, status,
+  colormapName, status,
   unappliedColorChanges,
 } from '@/store'
 import { updateColors } from '@/map'
 import AttributeSelect from './AttributeSelect.vue'
+import ColormapSelect from './ColormapSelect.vue'
 
 const showPicker = ref(false)
 
@@ -48,24 +48,10 @@ function update() {
         label="Color By Attribute"
         @select="(v) => colorBy = v"
       />
-      <v-tabs
-        v-model="colormapType"
-        density="compact"
-      >
-        <v-tab value="qualitative">
-          Qualitative
-        </v-tab>
-        <v-tab value="sequential">
-          Sequential
-        </v-tab>
-        <v-tab value="diverging">
-          Diverging
-        </v-tab>
-      </v-tabs>
-      <v-select
-        v-model="colormapName"
+      <ColormapSelect
+        :model="colormapName"
         label="Colormap"
-        :items="colorbrewer.schemeGroups[colormapType]"
+        @select="(v: string) => colormapName = v"
       />
       <v-btn
         v-if="unappliedColorChanges"

--- a/hips_viewer/src/ColorOptions.vue
+++ b/hips_viewer/src/ColorOptions.vue
@@ -22,7 +22,10 @@ function update() {
 </script>
 
 <template>
-  <v-card variant="outlined">
+  <v-card
+    variant="outlined"
+    width="350"
+  >
     <div class="menu-title">
       Color Options
     </div>
@@ -38,7 +41,7 @@ function update() {
         v-model="selectedColor"
         class="mb-3"
         mode="rgb"
-        width="375px"
+        width="315px"
         hide-inputs
         flat
       />
@@ -75,7 +78,7 @@ function update() {
     display: none
 }
 .v-color-picker-preview__track {
-    width: 350px !important;
+    width: 300px !important;
     padding-left: 20px;
 }
  .v-treeview-node__content {

--- a/hips_viewer/src/ColormapPreview.vue
+++ b/hips_viewer/src/ColormapPreview.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+const props = defineProps<{
+  colors: string[]
+  type: string
+}>()
+const canvas = ref()
+
+function draw() {
+  const ctx = canvas.value.getContext('2d')
+  const rect = [0, 0, canvas.value.width, canvas.value.height]
+  ctx.clearRect(...rect)
+  if (props.type === 'categorical') {
+    props.colors.forEach((color: string, index: number) => {
+      ctx.fillStyle = color
+      const start = canvas.value.width / props.colors.length * index
+      const end = canvas.value.width / props.colors.length * (index + 1)
+      ctx.fillRect(start, 0, end, canvas.value.height)
+    })
+  }
+  else if (props.type === 'sequential') {
+    const gradient = ctx.createLinearGradient(0, 0, canvas.value.width, 0)
+    props.colors.forEach((color: string, index: number) => {
+      gradient.addColorStop(index / (props.colors.length - 1), color)
+    })
+    ctx.fillStyle = gradient
+    ctx.fillRect(...rect)
+  }
+}
+
+onMounted(draw)
+</script>
+
+<template>
+  <canvas
+    ref="canvas"
+    class="canvas"
+  />
+</template>
+
+<style scoped>
+.canvas {
+    border: 1px solid black;
+    height: 20px;
+    width: 100%;
+}
+</style>

--- a/hips_viewer/src/ColormapSelect.vue
+++ b/hips_viewer/src/ColormapSelect.vue
@@ -1,15 +1,78 @@
 <script setup lang="ts">
 import { colormaps } from '@/colors'
+import ColormapPreview from './ColormapPreview.vue'
 
 const props = defineProps<{
   label: string
   model: any
 }>()
 const emit = defineEmits(['select'])
-
-console.log(props.model, emit, colormaps)
 </script>
 
 <template>
-  {{ props.label }}
+  <v-select
+    :model-value="props.model"
+    :label="props.label"
+    :items="colormaps"
+    item-title="name"
+    item-value="name"
+    density="compact"
+    class="colormap-select"
+    hide-details
+    @update:model-value="(v: string) => emit('select', v)"
+  >
+    <template #selection="{ item }">
+      <v-list-item
+        style="width: 100%"
+        class="colormap-item"
+      >
+        <template #title>
+          {{ item.title }}
+          <v-chip
+            size="x-small"
+            style="float:right"
+          >
+            {{ item.raw.type }}
+          </v-chip>
+        </template>
+        <template #subtitle>
+          <ColormapPreview
+            :colors="item.raw.colors"
+            :type="item.raw.type"
+          />
+        </template>
+      </v-list-item>
+    </template>
+    <template #item="{ props: itemProps, item }">
+      <v-list-item
+        v-bind="itemProps"
+        class="colormap-item"
+      >
+        <template #title>
+          {{ item.title }}
+          <v-chip
+            size="x-small"
+            style="float:right"
+          >
+            {{ item.raw.type }}
+          </v-chip>
+        </template>
+        <template #subtitle>
+          <ColormapPreview
+            :colors="item.raw.colors"
+            :type="item.raw.type"
+          />
+        </template>
+      </v-list-item>
+    </template>
+  </v-select>
 </template>
+
+<style>
+.colormap-select .v-select__selection {
+  width: 100%
+}
+.colormap-item .v-list-item-subtitle {
+  opacity: 100% !important
+}
+</style>

--- a/hips_viewer/src/ColormapSelect.vue
+++ b/hips_viewer/src/ColormapSelect.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { colormaps } from '@/colors'
+
+const props = defineProps<{
+  label: string
+  model: any
+}>()
+const emit = defineEmits(['select'])
+
+console.log(props.model, emit, colormaps)
+</script>
+
+<template>
+  {{ props.label }}
+</template>

--- a/hips_viewer/src/HistogramMenu.vue
+++ b/hips_viewer/src/HistogramMenu.vue
@@ -9,6 +9,7 @@ import { histAttribute, histNumBuckets, cellData, chartData, showHistogram, hist
   histSelectionType, histSelectedBars, histCellIdsDirty, histPrevViewport,
   histogramScale, histCellIds, selectedCellIds, cells, map, cellFeature, selectedColor,
   filterMatchCellIds, histColormapName, colormapName } from '@/store'
+import { colormaps } from './colors'
 
 import AttributeSelect from './AttributeSelect.vue'
 import ColormapSelect from './ColormapSelect.vue'
@@ -133,7 +134,7 @@ watchEffect(async () => {
   changeHistSelection()
 })
 
-watch([histNumBuckets, histCellIds, histColormapName], () => {
+watch([histNumBuckets, histCellIds], () => {
   histSelectedBars.value = new Set<number>()
   cellData.value = cellDistribution()
 })
@@ -144,9 +145,11 @@ watch([
 ], () => {
   if (!cellData.value) return
 
+  const colormap = colormaps.find(cmap => cmap.name === histColormapName.value)
+
   const labels = cellData.value.map(c => c.key)
   const colors = cellData.value.map((c, index) => {
-    return histSelectedBars.value.has(index) ? selectedColor.value : c.color()
+    return histSelectedBars.value.has(index) ? selectedColor.value : c.color(colormap)
   })
   const counts = cellData.value.map((c) => {
     if (!c.cellIds) return 0

--- a/hips_viewer/src/HistogramMenu.vue
+++ b/hips_viewer/src/HistogramMenu.vue
@@ -133,7 +133,7 @@ watchEffect(async () => {
   changeHistSelection()
 })
 
-watch([histNumBuckets, histCellIds], () => {
+watch([histNumBuckets, histCellIds, histColormapName], () => {
   histSelectedBars.value = new Set<number>()
   cellData.value = cellDistribution()
 })
@@ -270,7 +270,7 @@ watch([
       </div>
       <v-label>({{ histIncludedCellIds.size }} / {{ cells.length }})</v-label>
 
-      <v-expansion-panels class="pt-2">
+      <v-expansion-panels class="pt-2 color-options">
         <v-expansion-panel>
           <v-expansion-panel-title>Color Options</v-expansion-panel-title>
           <v-expansion-panel-text>
@@ -295,6 +295,13 @@ watch([
 
 <style>
 .chart-container {
-    min-width: 500px;
+  min-width: 500px;
+}
+.color-options .v-expansion-panel-title {
+  padding: 0px 4px;
+  min-height: 40px !important;
+}
+.color-options .v-expansion-panel-text__wrapper {
+  padding: 0px!important
 }
 </style>

--- a/hips_viewer/src/HistogramMenu.vue
+++ b/hips_viewer/src/HistogramMenu.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import colorbrewer from 'colorbrewer'
 
 import { ref, watchEffect, watch, onMounted, computed } from 'vue'
 import { Chart as ChartJS, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js'
@@ -9,9 +8,10 @@ import { cellDistribution } from '@/utils'
 import { histAttribute, histNumBuckets, cellData, chartData, showHistogram, histPrevSelectedCellIds,
   histSelectionType, histSelectedBars, histCellIdsDirty, histPrevViewport,
   histogramScale, histCellIds, selectedCellIds, cells, map, cellFeature, selectedColor,
-  filterMatchCellIds, histColormapName, histColormapType, colormapType, colormapName } from '@/store'
+  filterMatchCellIds, histColormapName, colormapName } from '@/store'
 
 import AttributeSelect from './AttributeSelect.vue'
+import ColormapSelect from './ColormapSelect.vue'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
 
@@ -45,7 +45,6 @@ const debouncedUpdateHistBuckets = (n: number) => {
 }
 
 function syncWithMapColors() {
-  histColormapType.value = colormapType.value
   histColormapName.value = colormapName.value
 }
 
@@ -275,24 +274,10 @@ watch([
         <v-expansion-panel>
           <v-expansion-panel-title>Color Options</v-expansion-panel-title>
           <v-expansion-panel-text>
-            <v-tabs
-              v-model="histColormapType"
-              density="compact"
-            >
-              <v-tab value="qualitative">
-                Qualitative
-              </v-tab>
-              <v-tab value="sequential">
-                Sequential
-              </v-tab>
-              <v-tab value="diverging">
-                Diverging
-              </v-tab>
-            </v-tabs>
-            <v-select
-              v-model="histColormapName"
+            <ColormapSelect
+              :model="histColormapName"
               label="Colormap"
-              :items="colorbrewer.schemeGroups[histColormapType]"
+              @select="(v:string) => histColormapName = v"
             />
 
             <v-btn

--- a/hips_viewer/src/colors.ts
+++ b/hips_viewer/src/colors.ts
@@ -1,0 +1,137 @@
+// Import any schemes available at https://d3js.org/d3-scale-chromatic
+import {
+  schemeCategory10,
+  schemeAccent,
+  schemeDark2,
+  schemeObservable10,
+  schemePaired,
+  schemePastel1,
+  schemePastel2,
+  schemeSet1,
+  schemeSet2,
+  schemeSet3,
+  schemeTableau10,
+  interpolateTurbo,
+  interpolateViridis,
+  interpolateMagma,
+  interpolatePlasma,
+  interpolateCividis,
+  interpolateWarm,
+  interpolateCool,
+} from 'd3-scale-chromatic'
+import type { Colormap } from './types'
+
+const N_SAMPLES = 10
+
+function createCategoricalColormap(name: string, scheme: readonly string[]): Colormap {
+  return {
+    name,
+    type: 'categorical',
+    colors: [...scheme],
+    getStringColorFunction: (domain: string[]) => {
+      return (value: string) => {
+        const index = domain.indexOf(value)
+        if (index >= 0) {
+          const proportion = index / domain.length
+          return scheme[Math.round(scheme.length * proportion)]
+        }
+        return 'transparent'
+      }
+    },
+    getNumericColorFunction: (domain: [number, number]) => {
+      return (value: number) => {
+        const proportion = (value - domain[0]) / (domain[1] - domain[0])
+        return scheme[Math.round(scheme.length * proportion)]
+      }
+    },
+  }
+}
+
+function createSequentialColormap(name: string, interpolate: (v: number) => string): Colormap {
+  return {
+    name,
+    type: 'sequential',
+    colors: [...Array(N_SAMPLES).keys()].map(i => interpolate(i / (N_SAMPLES - 1))),
+    getStringColorFunction: (domain: string[]) => {
+      return (value: string) => {
+        const index = domain.indexOf(value)
+        if (index >= 0) {
+          const proportion = index / domain.length
+          return interpolate(proportion)
+        }
+        return 'transparent'
+      }
+    },
+    getNumericColorFunction: (domain: [number, number]) => {
+      return (value: number) => {
+        const proportion = (value - domain[0]) / (domain[1] - domain[0])
+        return interpolate(proportion)
+      }
+    },
+  }
+}
+
+export const colormaps: Colormap[] = [
+  {
+    name: 'Category10',
+    scheme: schemeCategory10,
+  }, {
+    name: 'Accent',
+    scheme: schemeAccent,
+  }, {
+    name: 'Dark2',
+    scheme: schemeDark2,
+  }, {
+    name: 'Observable10',
+    scheme: schemeObservable10,
+  }, {
+    name: 'Paired',
+    scheme: schemePaired,
+  }, {
+    name: 'Pastel1',
+    scheme: schemePastel1,
+  }, {
+    name: 'Pastel2',
+    scheme: schemePastel2,
+  }, {
+    name: 'Set1',
+    scheme: schemeSet1,
+  }, {
+    name: 'Set2',
+    scheme: schemeSet2,
+  }, {
+    name: 'Set3',
+    scheme: schemeSet3,
+  }, {
+    name: 'Tableau10',
+    scheme: schemeTableau10,
+  }, {
+    name: 'Turbo',
+    interpolate: interpolateTurbo,
+  }, {
+    name: 'Viridis',
+    interpolate: interpolateViridis,
+  }, {
+    name: 'Magma',
+    interpolate: interpolateMagma,
+  }, {
+    name: 'Plasma',
+    interpolate: interpolatePlasma,
+  }, {
+    name: 'Cvidis',
+    interpolate: interpolateCividis,
+  }, {
+    name: 'Warm',
+    interpolate: interpolateWarm,
+  }, {
+    name: 'Cool',
+    interpolate: interpolateCool,
+  },
+].map((cmap) => {
+  if (cmap.scheme !== undefined) {
+    return createCategoricalColormap(cmap.name, cmap.scheme)
+  }
+  if (cmap.interpolate !== undefined) {
+    return createSequentialColormap(cmap.name, cmap.interpolate)
+  }
+}).filter(cmap => cmap !== undefined)

--- a/hips_viewer/src/colors.ts
+++ b/hips_viewer/src/colors.ts
@@ -32,8 +32,7 @@ function createCategoricalColormap(name: string, scheme: readonly string[]): Col
       return (value: string) => {
         const index = domain.indexOf(value)
         if (index >= 0) {
-          const proportion = index / domain.length
-          return scheme[Math.round(scheme.length * proportion)]
+          return scheme[index % scheme.length]
         }
         return 'transparent'
       }

--- a/hips_viewer/src/colors.ts
+++ b/hips_viewer/src/colors.ts
@@ -19,9 +19,21 @@ import {
   interpolateWarm,
   interpolateCool,
 } from 'd3-scale-chromatic'
-import type { Colormap } from './types'
+import type { Colormap, RGB } from './types'
+import { hexToRgb } from './utils'
 
 const N_SAMPLES = 10
+
+function stringToRGB(colorString: string): RGB {
+  if (colorString.includes('#')) {
+    return hexToRgb(colorString)
+  }
+  else if (colorString.includes('rgb')) {
+    const rgb = colorString.replace('rgb(', '').split(',').map((v: string) => parseInt(v) / 255)
+    return { r: rgb[0], g: rgb[1], b: rgb[2] }
+  }
+  return { r: 0, g: 0, b: 0 }
+}
 
 function createCategoricalColormap(name: string, scheme: readonly string[]): Colormap {
   return {
@@ -32,15 +44,16 @@ function createCategoricalColormap(name: string, scheme: readonly string[]): Col
       return (value: string) => {
         const index = domain.indexOf(value)
         if (index >= 0) {
-          return scheme[index % scheme.length]
+          return hexToRgb(scheme[index % scheme.length])
         }
-        return 'transparent'
+        return { r: 0, g: 0, b: 0 }
       }
     },
     getNumericColorFunction: (domain: [number, number]) => {
       return (value: number) => {
         const proportion = (value - domain[0]) / (domain[1] - domain[0])
-        return scheme[Math.round(scheme.length * proportion)]
+        const index = Math.round((scheme.length - 1) * proportion)
+        return hexToRgb(scheme[index])
       }
     },
   }
@@ -56,15 +69,15 @@ function createSequentialColormap(name: string, interpolate: (v: number) => stri
         const index = domain.indexOf(value)
         if (index >= 0) {
           const proportion = index / domain.length
-          return interpolate(proportion)
+          return stringToRGB(interpolate(proportion))
         }
-        return 'transparent'
+        return { r: 0, g: 0, b: 0 }
       }
     },
     getNumericColorFunction: (domain: [number, number]) => {
       return (value: number) => {
         const proportion = (value - domain[0]) / (domain[1] - domain[0])
-        return interpolate(proportion)
+        return stringToRGB(interpolate(proportion))
       }
     },
   }

--- a/hips_viewer/src/map.ts
+++ b/hips_viewer/src/map.ts
@@ -1,5 +1,4 @@
 import geo from 'geojs'
-import colorbrewer from 'colorbrewer'
 
 import {
   cells, map, maxZoom, cellFeature, pointFeature,
@@ -9,11 +8,11 @@ import {
   filterMatchCellIds,
 } from '@/store'
 import {
-  selectCell,
-  clusterFirstPoint, numericColormap,
+  selectCell, clusterFirstPoint,
   getCellAttribute, hexToRgb,
 } from './utils'
 import type { Cell } from './types'
+import { colormaps } from './colors'
 
 export async function createMap(mapId: string, tileUrl: string) {
   const tileInfo = await (await fetch(tileUrl)).json()
@@ -121,7 +120,8 @@ export function lassoSelect(polygon: { x: number, y: number }[]) {
 }
 
 export function updateColors() {
-  if (!(colormapName.value && colorBy.value && cells.value && colorLegend.value)) {
+  const colormap = colormaps.find(cmap => cmap.name === colormapName.value)
+  if (!(colormap && colorBy.value && cells.value && colorLegend.value)) {
     colorLegend.value.categories([])
     return
   }
@@ -131,25 +131,32 @@ export function updateColors() {
   ).map(
     (v: any) => isNaN(parseFloat(v)) ? v : parseFloat(v),
   ).filter((v: any) => v !== undefined))]
-  // @ts-ignore
-  const colormapSets = colorbrewer[colormapName.value]
-  let colors = colormapSets[values.length]
-  if (!colors) colors = colormapSets[Math.max(...Object.keys(colormapSets).map(v => parseInt(v)))]
-  const rgbColors = colors.map(hexToRgb)
 
-  let colormapFunction
+  let getCellColor
+  const colors = colormap.colors
   if (values.every(v => typeof v === 'number')) {
-    const range = [Math.min(...values), Math.max(...values)]
+    const domain: [number, number] = [Math.min(...values), Math.max(...values)]
+    const colorFunction = colormap.getNumericColorFunction(domain)
+    getCellColor = (cell: any) => {
+      const value = getCellAttribute(cell, colorBy.value)
+      if (value === undefined) return { r: 0, g: 0, b: 0 }
+      return hexToRgb(colorFunction(value as number))
+    }
     colorLegend.value.categories([{
       name: colorBy.value,
       type: 'continuous',
       scale: 'linear',
-      domain: range,
+      domain,
       colors,
     }])
-    colormapFunction = numericColormap(range[0], range[1], rgbColors)
   }
   else {
+    const colorFunction = colormap.getStringColorFunction(values as string[])
+    getCellColor = (cell: any) => {
+      const value = getCellAttribute(cell, colorBy.value)
+      if (value === undefined) return { r: 0, g: 0, b: 0 }
+      return hexToRgb(colorFunction(value as string))
+    }
     colorLegend.value.categories([{
       name: colorBy.value,
       type: 'discrete',
@@ -157,24 +164,10 @@ export function updateColors() {
       domain: values,
       colors,
     }])
-    colormapFunction = (v: any) => {
-      const index = values.indexOf(v)
-      if (index >= 0) {
-        const proportion = values.indexOf(v) / values.length
-        return rgbColors[Math.round(rgbColors.length * proportion)]
-      }
-
-      return { r: 0, g: 0, b: 0 }
-    }
   }
   colorLegend.value.width(colorLegend.value.canvas().clientWidth - 20)
 
-  if (colormapFunction) {
-    const getCellColor = (cell: any) => {
-      const value = getCellAttribute(cell, colorBy.value)
-      if (value === undefined) return { r: 0, g: 0, b: 0 }
-      return colormapFunction(value)
-    }
+  if (getCellColor) {
     cellColors.value = Object.fromEntries(cells.value.map((cell: Cell) => [cell.id, getCellColor(cell)]))
     updateColorFunctions()
   }

--- a/hips_viewer/src/map.ts
+++ b/hips_viewer/src/map.ts
@@ -8,8 +8,7 @@ import {
   filterMatchCellIds,
 } from '@/store'
 import {
-  selectCell, clusterFirstPoint, getCellAttribute,
-  numericColormap, getCellAttribute, hexToRgb,
+  selectCell, getCellAttribute, clusterFirstPointId,
 } from './utils'
 import type { Cell } from './types'
 import { colormaps } from './colors'

--- a/hips_viewer/src/map.ts
+++ b/hips_viewer/src/map.ts
@@ -8,8 +8,7 @@ import {
   filterMatchCellIds,
 } from '@/store'
 import {
-  selectCell, clusterFirstPoint,
-  getCellAttribute, hexToRgb,
+  selectCell, clusterFirstPoint, getCellAttribute,
 } from './utils'
 import type { Cell } from './types'
 import { colormaps } from './colors'
@@ -140,7 +139,7 @@ export function updateColors() {
     getCellColor = (cell: any) => {
       const value = getCellAttribute(cell, colorBy.value)
       if (value === undefined) return { r: 0, g: 0, b: 0 }
-      return hexToRgb(colorFunction(value as number))
+      return colorFunction(value as number)
     }
     colorLegend.value.categories([{
       name: colorBy.value,
@@ -155,7 +154,7 @@ export function updateColors() {
     getCellColor = (cell: any) => {
       const value = getCellAttribute(cell, colorBy.value)
       if (value === undefined) return { r: 0, g: 0, b: 0 }
-      return hexToRgb(colorFunction(value as string))
+      return colorFunction(value as string)
     }
     colorLegend.value.categories([{
       name: colorBy.value,

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -52,12 +52,12 @@ export const cellData = ref<null | {
   count: number
 }[]>(null)
 export const chartData = ref()
-export const histColormapName = ref<string | undefined>('Paired')
+export const histColormapName = ref<string | undefined>('Set1')
 
 export const colorLegend = ref()
 export const selectedColor = ref('#000')
 export const colorBy = ref('classification')
-export const colormapName = ref<string | undefined>('Paired')
+export const colormapName = ref<string | undefined>('Set1')
 export const attributeOptions = ref()
 
 export const filterOptions = ref<FilterOption[]>()

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -52,15 +52,11 @@ export const cellData = ref<null | {
   count: number
 }[]>(null)
 export const chartData = ref()
-export const histColormapType = ref<'qualitative' | 'sequential' | 'diverging'>('qualitative')
 export const histColormapName = ref<string | undefined>('Paired')
 
 export const colorLegend = ref()
 export const selectedColor = ref('#000')
 export const colorBy = ref('classification')
-export const colormapType = ref<
-  'qualitative' | 'sequential' | 'diverging'
->('qualitative')
 export const colormapName = ref<string | undefined>('Paired')
 export const attributeOptions = ref()
 
@@ -72,8 +68,6 @@ export const filterPopulation = ref<'all' | 'selected'>('all')
 export const filterMatchCellIds = ref<Set<number>>(new Set<number>())
 
 // Store watchers
-watch(colormapType, () => colormapName.value = undefined)
-
 watch([selectedColor, colorBy, colormapName], () => {
   unappliedColorChanges.value = !!(
     selectedColor.value && colorBy.value && colormapName.value

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -37,3 +37,11 @@ export interface FilterOption {
     max: number | undefined
   }
 }
+
+export interface Colormap {
+  name: string
+  type: 'categorical' | 'sequential'
+  colors: string[]
+  getNumericColorFunction: (domain: [number, number]) => (value: number) => string
+  getStringColorFunction: (domain: string[]) => (value: string) => string
+}

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -38,10 +38,16 @@ export interface FilterOption {
   }
 }
 
+export interface RGB {
+  r: number
+  g: number
+  b: number
+}
+
 export interface Colormap {
   name: string
   type: 'categorical' | 'sequential'
   colors: string[]
-  getNumericColorFunction: (domain: [number, number]) => (value: number) => string
-  getStringColorFunction: (domain: string[]) => (value: string) => string
+  getNumericColorFunction: (domain: [number, number]) => (value: number) => RGB
+  getStringColorFunction: (domain: string[]) => (value: string) => RGB
 }

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -17,12 +17,10 @@ import {
   histColormapName,
 } from './store'
 import { colormaps } from './colors'
-import type { Cell, FilterOption } from './types'
-
-export interface RGB { r: number, g: number, b: number }
+import type { Cell, FilterOption, RGB } from './types'
 
 // from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
-export function hexToRgb(hex: string) {
+export function hexToRgb(hex: string): RGB {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
   if (result) {
     return {
@@ -31,7 +29,7 @@ export function hexToRgb(hex: string) {
       b: parseInt(result[3], 16) / 255,
     }
   }
-  return null
+  return { r: 0, g: 0, b: 0 }
 }
 
 // from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
@@ -301,7 +299,7 @@ export function cellDistribution() {
       key: `${v}`,
       count: counts[v] ?? 0,
       cellIds: cellIds[v],
-      color: () => colorFunction(v as string),
+      color: () => rgbToHex(colorFunction(v as string)),
     }))
   }
 
@@ -327,6 +325,6 @@ export function cellDistribution() {
     key: `${bucketedMin[v].toFixed(2)}`,
     count: bucketedCounts[v],
     cellIds: bucketedCellIds[v],
-    color: () => colorFunction(bucketedMin[v]),
+    color: () => rgbToHex(colorFunction(bucketedMin[v])),
   }))
 }

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -43,15 +43,6 @@ export function rgbToHex(color: RGB) {
   return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)
 }
 
-// from https://stackoverflow.com/questions/66123016/interpolate-between-two-colours-based-on-a-percentage-value
-export function colorInterpolate(rgbA: RGB, rgbB: RGB, proportion: number) {
-  return {
-    r: rgbA.r * (1 - proportion) + rgbB.r * proportion,
-    g: rgbA.g * (1 - proportion) + rgbB.g * proportion,
-    b: rgbA.b * (1 - proportion) + rgbB.b * proportion,
-  }
-}
-
 export function clusterAllPoints(data: any, current: any, i: number, allPoints: any[], filteredIds: number[]) {
   if (clusterIds.value[i]) return clusterIds.value[i]
   if (current.__cluster) {


### PR DESCRIPTION
This PR switches the library that we use for colormaps. Instead of `colorbrewer`, we now use `d3-scale-chromatic`, which includes these colormaps: https://d3js.org/d3-scale-chromatic

This PR creates new components `ColormapSelect` and `ColormapPreview`. The `ColormapSelect` component is used in `ColorOptions` and `HistogramMenu`. The `ColormapPreview` is used within the `ColormapSelect` component to show previews of each colormap option.

After some discussion about the colormap types we want to offer, it seems like we don't have a use case for diverging colormaps, so the colormap selection offers only "categorical" and "sequential" colormaps. Each colormap option has a chip next to the name to indicate the type.

Some screenshots applying a categorical colormap, "Set1":
Shown in `ColorOptions`:
<img width="1353" height="1083" alt="image" src="https://github.com/user-attachments/assets/1d491157-0592-4324-9a31-0a812cc24869" />

Shown in `HistogramMenu`:
<img width="1353" height="1083" alt="image" src="https://github.com/user-attachments/assets/4e12c7b7-14ca-4c15-a122-1a7e1f1f40f3" />


Some screenshots applying a sequential colormap, "viridis":
Shown in `ColorOptions`:
<img width="1353" height="1083" alt="image" src="https://github.com/user-attachments/assets/4e2e7960-5310-4646-a68a-1fb72e842453" />

Shown in `HistogramMenu`:
<img width="1353" height="1083" alt="image" src="https://github.com/user-attachments/assets/02d372c9-6e2a-4c4b-8586-268ec9fb5702" />

Additionally, this PR changes the default colormap from "Paired" to "Set1".
