### PR TITLE
Transform Menu

### DIFF
--- a/hips_viewer/package-lock.json
+++ b/hips_viewer/package-lock.json
@@ -12,6 +12,7 @@
         "@mdi/font": "7.4.47",
         "colorbrewer": "^1.6.1",
         "geojs": "^1.14.12",
+        "regl-scatterplot": "^1.14.1",
         "vue": "^3.5.13",
         "vue-chartjs": "^5.3.2",
         "vuetify": "^3.8.1"
@@ -2341,6 +2342,12 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@flekschas/utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.32.2.tgz",
+      "integrity": "sha512-RPF5WBXxA3WFKdTTDQS7gl7hd1z6kOMfJKj0p+9TRLJm/vQHvRC2Zt62axSQlbve8a82NtVN96aaGhsx5+ekvQ==",
+      "license": "MIT"
+    },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.5.tgz",
@@ -4007,6 +4014,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/camera-2d-simple": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camera-2d-simple/-/camera-2d-simple-3.0.0.tgz",
+      "integrity": "sha512-hBeuUeerQ2Repi/61PGyFkuJ9jt6IKAny7pjQo2w8/8uZh+RKvNLZQy4xbQeDH8FrlnFxAJDjyM4/yuLdOV5vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "~3.3.0"
+      },
+      "peerDependencies": {
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "node_modules/camera-2d-simple/node_modules/gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==",
+      "license": "MIT"
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001727",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
@@ -4842,6 +4867,19 @@
         "@jsdoc/salty": "^0.2.1"
       }
     },
+    "node_modules/dom-2d-camera": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.6.tgz",
+      "integrity": "sha512-HWfV26qjCfpOHa6X0PI1ZyZDhowk6skEs5f7aOwgewuJSP6IgPcK694ImYIOMGnDYK4vC4/Etsi26WpbJtS2vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camera-2d-simple": "^3.0.0",
+        "gl-matrix": "^3.3.0"
+      },
+      "peerDependencies": {
+        "gl-matrix": "^3.3.0"
+      }
+    },
     "node_modules/earcut": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
@@ -5595,8 +5633,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
       "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/gl-vec3": {
       "version": "1.1.3",
@@ -6841,6 +6878,12 @@
         "url": "https://github.com/sponsors/ahocevar"
       }
     },
+    "node_modules/pub-sub-es": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-3.0.0.tgz",
+      "integrity": "sha512-pf+6yCPsOfvDMru2LnsqdKSN8XQyF5HZzmEoKBvjMk4TILMUQiq1vxI6rC92T9ErY06sLXBmC1p7JGNFVB1pUQ==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -7060,6 +7103,48 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/regl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
+      "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
+      "license": "MIT"
+    },
+    "node_modules/regl-line": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/regl-line/-/regl-line-1.1.1.tgz",
+      "integrity": "sha512-IKcyiZq+nQg7x3mEmxf9kImM9CzmEyZDhCCfas2xVpsoiDJFEyILsuocD1G4dSXA/nC39za9OBw4FzYEgWNiUg==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "^3.3.0",
+        "regl": "^2.1.0"
+      },
+      "peerDependencies": {
+        "regl": "^2.1.0"
+      }
+    },
+    "node_modules/regl-scatterplot": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.14.1.tgz",
+      "integrity": "sha512-2WMrP6+pgoeckPpWrkHEqPpSJKjR3/QgNGBqctRCbzofsxDx3nDQh7541KnTH3LheGiZEofSJAoctdySgZG+tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@flekschas/utils": "^0.32.2",
+        "dom-2d-camera": "^2.2.6",
+        "earcut": "^3.0.1",
+        "gl-matrix": "~3.4.3",
+        "pub-sub-es": "~3.0.0",
+        "regl": "~2.1.1",
+        "regl-line": "~1.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "pub-sub-es": "~3.0.0",
+        "regl": "~2.1.1"
       }
     },
     "node_modules/require-from-string": {

--- a/hips_viewer/package.json
+++ b/hips_viewer/package.json
@@ -17,6 +17,7 @@
     "@mdi/font": "7.4.47",
     "colorbrewer": "^1.6.1",
     "geojs": "^1.14.12",
+    "regl-scatterplot": "^1.14.1",
     "vue": "^3.5.13",
     "vue-chartjs": "^5.3.2",
     "vuetify": "^3.8.1"

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -182,24 +182,6 @@ watch(cells, drawCells)
             icon
             v-bind="tooltipProps"
           >
-            <span class="material-symbols-outlined">palette</span>
-            <v-menu
-              activator="parent"
-              location="end"
-              :close-on-content-click="false"
-            >
-              <ColorOptions />
-            </v-menu>
-          </v-btn>
-        </template>
-        <span>Color Options</span>
-      </v-tooltip>
-      <v-tooltip>
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            icon
-            v-bind="tooltipProps"
-          >
             <span class="material-symbols-outlined">filter_alt</span>
             <v-menu
               activator="parent"
@@ -229,6 +211,24 @@ watch(cells, drawCells)
           </v-btn>
         </template>
         <span>Cell Histogram</span>
+      </v-tooltip>
+      <v-tooltip>
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            icon
+            v-bind="tooltipProps"
+          >
+            <span class="material-symbols-outlined">palette</span>
+            <v-menu
+              activator="parent"
+              location="end"
+              :close-on-content-click="false"
+            >
+              <ColorOptions />
+            </v-menu>
+          </v-btn>
+        </template>
+        <span>Color Options</span>
       </v-tooltip>
       <v-btn
         v-tooltip="'Toggle Tooltip'"

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -15,9 +15,10 @@ import {
 
 import CellDrawer from '@/CellDrawer.vue'
 import ColorOptions from '@/ColorOptions.vue'
-import { getCellAttribute } from './utils'
+import { getCellAttribute } from '@/utils'
 import HistogramMenu from '@/HistogramMenu.vue'
-import FilterMenu from './FilterMenu.vue'
+import FilterMenu from '@/FilterMenu.vue'
+import TransformMenu from '@/TransformMenu.vue'
 
 const props = defineProps<{
   id: number
@@ -146,6 +147,24 @@ watch(cells, drawCells)
       v-if="cells"
       class="actions"
     >
+      <v-tooltip>
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            icon
+            v-bind="tooltipProps"
+          >
+            <span class="material-symbols-outlined">transform</span>
+            <v-menu
+              activator="parent"
+              location="end"
+              :close-on-content-click="false"
+            >
+              <TransformMenu />
+            </v-menu>
+          </v-btn>
+        </template>
+        <span>UMAP Transforms</span>
+      </v-tooltip>
       <v-tooltip>
         <template #activator="{ props: tooltipProps }">
           <v-btn

--- a/hips_viewer/src/TransformMenu.vue
+++ b/hips_viewer/src/TransformMenu.vue
@@ -218,6 +218,28 @@ watch(selectedCellIds, updateScatterSelection)
           </template>
         </v-select>
       </div>
+      <div
+        v-if="scatterData && umapSelectedResult"
+        style="float: right"
+      >
+        <v-tooltip>
+          <template #activator="{ props: tooltipProps }">
+            <span
+              class="material-symbols-outlined"
+              v-bind="tooltipProps"
+            >
+              help
+            </span>
+          </template>
+          <div style="width: 200px">
+            <div style="font-weight: bold;">
+              Interactive scatterplot controls
+            </div>
+            <div>Drag to pan, scroll to zoom</div>
+            <div>(Shift + Drag) OR (Click and Hold for 1s, then Drag) to draw a lasso selection</div>
+          </div>
+        </v-tooltip>
+      </div>
       <canvas
         ref="scatterCanvas"
         class="scatter-canvas"

--- a/hips_viewer/src/TransformMenu.vue
+++ b/hips_viewer/src/TransformMenu.vue
@@ -90,8 +90,9 @@ function selectResult(selected: any) {
 
 function scatterSelect({ points }: any) {
   if (!scatterData.value) return
+  const pointSet = new Set(points)
   const selected = scatterData.value.map((p, i) => {
-    if (points.includes(i)) return p.id
+    if (pointSet.has(i)) return p.id
     return undefined
   }).filter(id => id) as number[]
   selectedCellIds.value = new Set(selected)

--- a/hips_viewer/src/TransformMenu.vue
+++ b/hips_viewer/src/TransformMenu.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { onMounted, ref, computed } from 'vue'
+import { fetchUMAPTransformResults, fetchUMAPTransforms } from '@/api'
+import { umapTransformResults, umapTransforms } from './store'
+import type { UMAPTransform, UMAPResult, TreeItem } from './types'
+
+const resultSelection = ref()
+const selectedResult = ref<UMAPResult>()
+
+const nestedResultOptions = computed(() => {
+  const nested: TreeItem[] = []
+  umapTransforms.value?.forEach((transform: UMAPTransform) => {
+    const parent: TreeItem = { title: `UMAPTransform ${transform.id}`, subtitle: transform.name, children: [] }
+    nested.push(parent)
+    const results = umapTransformResults.value[transform.id]
+    if (results?.length) {
+      results.forEach((result: UMAPResult) => {
+        parent.children?.push({ title: `UMAPResult ${result.id}`, value: result })
+      })
+    }
+    else {
+      parent.children?.push({
+        title: 'No results exist. Create results by running the `apply_transform ' + transform.id + '` management command on the server.',
+        disabled: true,
+      })
+    }
+  })
+  return nested
+})
+
+function init() {
+  fetchUMAPTransforms().then((transforms) => {
+    umapTransforms.value = transforms
+    transforms.forEach((t: UMAPTransform) => {
+      fetchUMAPTransformResults(t.id).then((results) => {
+        umapTransformResults.value[t.id] = results
+      })
+    })
+  })
+}
+
+function select(selected: any) {
+  if (resultSelection.value) resultSelection.value.blur()
+  selectedResult.value = selected
+}
+
+onMounted(init)
+</script>
+
+<template>
+  <v-card variant="outlined">
+    <div class="menu-title">
+      Transform Results
+    </div>
+    <v-card-text style="width: 350px">
+      <div
+        v-if="!umapTransforms"
+      >
+        <v-progress-linear
+          indeterminate
+          class="centered-row"
+        />
+        <v-label class="centered-row">
+          Fetching UMAP Transforms...
+        </v-label>
+      </div>
+      <div
+        v-else-if="umapTransforms && !umapTransforms.length"
+        class="centered-row"
+      >
+        <div class="centered-row">
+          No transforms found. Create transforms by running the `create_transform` management command on the server.
+        </div>
+      </div>
+      <div v-else>
+        <v-select
+          ref="resultSelection"
+          v-model="selectedResult"
+          label="UMAP Transform Result"
+          density="compact"
+          hide-details
+        >
+          <template #selection="{item}">
+            <v-list-item
+              style="width: 350px"
+              class="colormap-item"
+            >
+              <template #title>
+                UMAPResult{{ item.raw.id }}
+                <v-chip
+                  size="x-small"
+                  style="float:right"
+                >
+                  {{ item.raw.scatterplot_data.length }} cells
+                </v-chip>
+              </template>
+              <template #subtitle>
+                {{ item.raw.created }}
+              </template>
+            </v-list-item>
+          </template>
+          <template #no-data>
+            <v-treeview
+              :model-value:selected="[selectedResult]"
+              :items="nestedResultOptions"
+              item-disabled="disabled"
+              select-strategy="single-leaf"
+              density="compact"
+              open-on-click
+              fluid
+            >
+              <template #item="{ props }">
+                <v-list-item
+                  :class="props.value ? '' : 'half-opacity'"
+                  width="350px"
+                  @click="() => { if (props.value) select(props.value) }"
+                >
+                  {{ props.title }}
+                  <v-chip
+                    v-if="props.value?.scatterplot_data"
+                    size="x-small"
+                    style="float:right"
+                  >
+                    {{ props.value.scatterplot_data.length }} cells
+                  </v-chip>
+                  <div
+                    v-if="props.value?.created"
+                    class="half-opacity"
+                  >
+                    {{ props.value.created }}
+                  </div>
+                </v-list-item>
+              </template>
+            </v-treeview>
+          </template>
+        </v-select>
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<style>
+.centered-row {
+  display: flex;
+  justify-content: center;
+  column-gap: 15px;
+  padding: 4px;
+}
+.half-opacity {
+    opacity: 0.5;
+}
+</style>

--- a/hips_viewer/src/TransformMenu.vue
+++ b/hips_viewer/src/TransformMenu.vue
@@ -14,7 +14,7 @@ const scatterCanvas = ref()
 const scatterplot = ref()
 const resultSelection = ref()
 
-const nestedResultOptions = computed(() => {
+const nestedResults = computed(() => {
   const nested: TreeItem[] = []
   umapTransforms.value?.forEach((transform: UMAPTransform) => {
     const parent: TreeItem = { title: `UMAPTransform ${transform.id}`, subtitle: transform.name, children: [] }
@@ -184,7 +184,7 @@ watch(selectedCellIds, updateScatterSelection)
           <template #no-data>
             <v-treeview
               :model-value:selected="[umapSelectedResult]"
-              :items="nestedResultOptions"
+              :items="nestedResults"
               item-disabled="disabled"
               select-strategy="single-leaf"
               density="compact"

--- a/hips_viewer/src/api.ts
+++ b/hips_viewer/src/api.ts
@@ -52,10 +52,10 @@ export async function fetchCellColumns() {
 
 export async function fetchUMAPTransforms() {
   const url = `${baseURL}/umap/transforms`
-  return await cachedFetch(url, 'umap-cache')
+  return (await fetch(url)).json()
 }
 
 export async function fetchUMAPTransformResults(transformId: number) {
   const url = `${baseURL}/umap/transforms/${transformId}/results`
-  return await cachedFetch(url, 'umap-cache')
+  return (await fetch(url)).json()
 }

--- a/hips_viewer/src/api.ts
+++ b/hips_viewer/src/api.ts
@@ -49,3 +49,13 @@ export async function fetchCellColumns() {
   const url = `${baseURL}/cells/columns`
   return await cachedFetch(url, 'cell-data-cache')
 }
+
+export async function fetchUMAPTransforms() {
+  const url = `${baseURL}/umap/transforms`
+  return await cachedFetch(url, 'umap-cache')
+}
+
+export async function fetchUMAPTransformResults(transformId: number) {
+  const url = `${baseURL}/umap/transforms/${transformId}/results`
+  return await cachedFetch(url, 'umap-cache')
+}

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -73,6 +73,7 @@ export const filterMatchCellIds = ref<Set<number>>(new Set<number>())
 
 export const umapTransforms = ref<UMAPTransform[]>()
 export const umapTransformResults = ref<Record<number, UMAPResult[]>>({})
+export const umapSelectedResult = ref<UMAPResult>()
 
 // Store watchers
 watch(colormapType, () => colormapName.value = undefined)

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -4,7 +4,7 @@ import {
   resetFilterOptions,
   resetFilterVectorIndices,
 } from './utils'
-import type { FilterOption } from './types'
+import type { FilterOption, UMAPTransform, UMAPResult } from './types'
 import { updateColorFunctions, updateOpacityFunctions } from './map'
 
 // Store variables
@@ -70,6 +70,9 @@ export const currentFilters = ref<Record<string, (string | number)[]>>({})
 export const hiddenFilters = ref<Set<string>>(new Set())
 export const filterPopulation = ref<'all' | 'selected'>('all')
 export const filterMatchCellIds = ref<Set<number>>(new Set<number>())
+
+export const umapTransforms = ref<UMAPTransform[]>()
+export const umapTransformResults = ref<Record<number, UMAPResult[]>>({})
 
 // Store watchers
 watch(colormapType, () => colormapName.value = undefined)

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -25,7 +25,9 @@ export interface Thumbnail {
 
 export interface TreeItem {
   title: string
-  value?: string
+  subtitle?: string
+  disabled?: boolean
+  value?: any
   children?: TreeItem[]
 }
 

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -37,3 +37,18 @@ export interface FilterOption {
     max: number | undefined
   }
 }
+
+export interface UMAPTransform {
+  id: number
+  name: string
+  created: string
+  column_names: string[]
+  umap_kwargs: Record<string, any>
+}
+
+export interface UMAPResult {
+  id: number
+  created: string
+  transform: number
+  scatterplot_data: number[][]
+}

--- a/hips_viewer/src/types.ts
+++ b/hips_viewer/src/types.ts
@@ -52,5 +52,11 @@ export interface UMAPResult {
   id: number
   created: string
   transform: number
-  scatterplot_data: number[][]
+  scatterplot_data: ScatterPoint[]
+}
+
+export interface ScatterPoint {
+  id: number
+  x: number
+  y: number
 }

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -18,7 +18,7 @@ import {
   histCellIds,
   histColormapName,
 } from './store'
-import type { Cell, FilterOption } from './types'
+import type { Cell, FilterOption, ScatterPoint } from './types'
 
 export interface RGB { r: number, g: number, b: number }
 
@@ -366,5 +366,18 @@ export function cellDistribution() {
       const colormapFunction = numericColormap(vmin, vmax, rgbColors)
       return rgbToHex(colormapFunction(bucketedMin[v]))
     },
+  }))
+}
+
+// regl-scatterplot requires points to be normalized for performance
+export function normalizePoints(points: ScatterPoint[]) {
+  const xMin = Math.min(...points.map(p => p.x))
+  const xMax = Math.max(...points.map(p => p.x))
+  const yMin = Math.min(...points.map(p => p.y))
+  const yMax = Math.max(...points.map(p => p.y))
+  return points.map(p => ({
+    ...p,
+    x: (p.x - xMin) / (xMax - xMin),
+    y: (p.y - yMin) / (yMax - yMin),
   }))
 }


### PR DESCRIPTION
This PR adds the Transform Menu, which allows a user to select an existing `UMAPResult` object and view its data on an interactive scatterplot (implemented with `regl-scatterplot` https://github.com/flekschas/regl-scatterplot).

<img width="1355" height="1086" alt="image" src="https://github.com/user-attachments/assets/25d1e1d8-2ac7-4884-8faf-5a8268b794a2" />
