### PR TITLE
Normalize UMAP result data during creation

### DIFF
--- a/hips_server/tcga/umap.py
+++ b/hips_server/tcga/umap.py
@@ -42,6 +42,8 @@ def get_image_and_cell_sets(**kwargs):
 
 def parse_number(v):
     try:
+        if v is None:
+            return None
         if np.isnan(float(v)):
             return None
         return float(v)
@@ -146,6 +148,8 @@ def create_transform_result(**kwargs):
     print(f'Applying transform to {len(cells)} cells.')
     output_data = transform.transform(input_data)
     df = pd.DataFrame(output_data, columns=['x', 'y'])
+    # normalize
+    df = (df - df.min()) / (df.max() - df.min())
     df['id'] = [cell.id for cell in cells]
 
     print('Creating UMAPResult object.')

--- a/hips_viewer/src/TransformMenu.vue
+++ b/hips_viewer/src/TransformMenu.vue
@@ -8,7 +8,7 @@ import {
   cellColors, selectedColor,
 } from './store'
 import type { UMAPTransform, UMAPResult, TreeItem, Cell, ScatterPoint } from './types'
-import { normalizePoints, rgbToHex } from './utils'
+import { rgbToHex } from './utils'
 
 const scatterCanvas = ref()
 const scatterplot = ref()
@@ -39,10 +39,9 @@ const imageCellIds = computed(() => new Set(cells.value.map((cell: Cell) => cell
 
 const scatterData = computed(() => {
   if (!umapSelectedResult.value) return undefined
-  const currentData = umapSelectedResult.value.scatterplot_data.filter((p: ScatterPoint) => {
+  return umapSelectedResult.value.scatterplot_data.filter((p: ScatterPoint) => {
     return imageCellIds.value.has(p.id) && (!filterMatchCellIds.value.size || filterMatchCellIds.value.has(p.id))
   })
-  return normalizePoints(currentData)
 })
 
 const scatterSelectedIndices = computed(() => scatterData.value?.map((p, i) => {

--- a/hips_viewer/src/utils.ts
+++ b/hips_viewer/src/utils.ts
@@ -16,7 +16,7 @@ import {
   statusProgress,
   cellVectorsProcessed,
 } from './store'
-import type { Cell, FilterOption, Colormap, RGB, ScatterPoint } from './types'
+import type { Cell, FilterOption, Colormap, RGB } from './types'
 
 // from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 export function hexToRgb(hex: string): RGB {
@@ -309,19 +309,6 @@ export function cellDistribution() {
       const colorFunction = colormap.getNumericColorFunction([vmin, vmax])
       return rgbToHex(colorFunction(bucketedMin[v]))
     },
-  }))
-}
-
-// regl-scatterplot requires points to be normalized for performance
-export function normalizePoints(points: ScatterPoint[]) {
-  const xMin = Math.min(...points.map(p => p.x))
-  const xMax = Math.max(...points.map(p => p.x))
-  const yMin = Math.min(...points.map(p => p.y))
-  const yMax = Math.max(...points.map(p => p.y))
-  return points.map(p => ({
-    ...p,
-    x: (p.x - xMin) / (xMax - xMin),
-    y: (p.y - yMin) / (yMax - yMin),
   }))
 }
 


### PR DESCRIPTION
Resolves #21 

This PR adds a line to normalize UMAP result data prior to creating a UMAPResult object. The client no longer needs to normalize the data for plotting with `regl-scatterplot`.

Note: This invalidates any previously generated `UMAPResult` objects, which should be deleted. I recommend using `manage.py shell` for this, since these objects can be quite large and can cause the Django Admin Console in the browser to crash.