### PR TITLE
Replace image tabs with selection

### DIFF
--- a/hips_viewer/src/App.vue
+++ b/hips_viewer/src/App.vue
@@ -22,47 +22,29 @@ onMounted(() => {
     <v-img
       src="/logo.png"
       max-width="120"
+      class="mx-6"
     />
-    <template #extension>
-      <v-tabs
-        v-model="currentImage"
-        height="30"
-        center-active
-        grow
-      >
-        <v-tab
-          v-for="image, index in images"
-          :key="index"
-          :text="image.name"
-          :value="image"
-        />
-
-        <v-tab
-          v-if="images && images.length == 0"
-          value="no-image"
-        >
-          No images found
-        </v-tab>
-      </v-tabs>
-    </template>
+    <v-spacer />
+    <v-select
+      v-model="currentImage"
+      :items="images"
+      item-title="name"
+      max-width="300px"
+      placeholder="Select an Image"
+      return-object
+      hide-details
+    />
   </v-toolbar>
 
-  <v-tabs-window v-model="currentImage">
-    <v-tabs-window-item
-      v-for="image, index in images"
-      :key="index"
-      :value="image"
-    >
-      <ImageView
-        :id="index"
-        :image="image"
-      />
-    </v-tabs-window-item>
-  </v-tabs-window>
+  <ImageView
+    v-if="currentImage"
+    :id="currentImage.id"
+    :image="currentImage"
+  />
 </template>
 
 <style>
-html, body, #app, .v-window, .v-window__container, .v-window-item, .map-container, .map{
+html, body, #app, .map-container, .map{
   width: 100%;
   height: 100%;
   padding: 0;
@@ -72,9 +54,6 @@ html, body, #app, .v-window, .v-window__container, .v-window-item, .map-containe
 .v-toolbar__content {
   display: flex;
   justify-content: space-between;
-  padding: 4px 16px;
-}
-.v-toolbar__extension {
-  height: 30px !important;
+  padding: 4px 0px;
 }
 </style>

--- a/hips_viewer/src/App.vue
+++ b/hips_viewer/src/App.vue
@@ -3,11 +3,26 @@ import { onMounted } from 'vue'
 import { fetchImages } from '@/api'
 import ImageView from '@/ImageView.vue'
 import { currentImage, images, status } from './store'
+import type { Image } from './types'
 
 onMounted(() => {
+  let targetId: number | undefined
+  const path = window.location.pathname
+  const pattern = /\/images\/(\d+)/g
+  path.matchAll(pattern).forEach((match) => {
+    targetId = parseInt(match[1])
+  })
+
   fetchImages().then((data) => {
     images.value = data
-    if (images.value.length) currentImage.value = images.value[0]
+    if (images.value.length) {
+      if (targetId) {
+        currentImage.value = images.value.find((im: Image) => im.id === targetId)
+      }
+      if (!currentImage.value) {
+        currentImage.value = images.value[0]
+      }
+    }
   })
 })
 </script>

--- a/hips_viewer/src/App.vue
+++ b/hips_viewer/src/App.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted } from 'vue'
 import { fetchImages } from '@/api'
 import ImageView from '@/ImageView.vue'
-
-const images = ref()
-const currentImage = ref()
+import { currentImage, images } from './store'
 
 onMounted(() => {
   fetchImages().then((data) => {

--- a/hips_viewer/src/App.vue
+++ b/hips_viewer/src/App.vue
@@ -2,7 +2,7 @@
 import { onMounted } from 'vue'
 import { fetchImages } from '@/api'
 import ImageView from '@/ImageView.vue'
-import { currentImage, images } from './store'
+import { currentImage, images, status } from './store'
 
 onMounted(() => {
   fetchImages().then((data) => {
@@ -29,6 +29,7 @@ onMounted(() => {
       item-title="name"
       max-width="300px"
       placeholder="Select an Image"
+      :disabled="!!status"
       return-object
       hide-details
     />

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -98,6 +98,7 @@ function resizeCellDrawer(e: MouseEvent) {
 }
 
 onMounted(init)
+watch(() => props.id, init)
 watch(cells, drawCells)
 </script>
 

--- a/hips_viewer/src/ImageView.vue
+++ b/hips_viewer/src/ImageView.vue
@@ -109,11 +109,11 @@ watch(cells, drawCells)
     <div
       :id="mapId"
       class="map"
-      :style="{height: `calc(100% - ${cellDrawerHeight + 70}px) !important`}"
+      :style="{height: `calc(100% - ${cellDrawerHeight}px) !important`}"
     />
     <div
       class="status"
-      :style="{bottom: cellDrawerHeight + (colorLegendShown ? 180 : 80) + 'px'}"
+      :style="{bottom: cellDrawerHeight + (colorLegendShown ? 110 : 10) + 'px'}"
     >
       <v-card
         v-if="status"
@@ -135,7 +135,7 @@ watch(cells, drawCells)
     </div>
     <span
       class="material-symbols-outlined cell-drawer-resize"
-      :style="{bottom: cellDrawerHeight + 55 + 'px'}"
+      :style="{bottom: cellDrawerHeight - 15 + 'px'}"
       @mousedown="cellDrawerResizing = true"
       @mouseup="cellDrawerResizing = false"
     >
@@ -281,7 +281,7 @@ watch(cells, drawCells)
 }
 .cell-drawer {
     width: 100%;
-    bottom: 70px;
+    bottom: 0px;
     border-top: 2px solid black !important;
 }
 .cell-drawer-resize {
@@ -293,7 +293,7 @@ watch(cells, drawCells)
 }
 .actions {
     position: absolute;
-    top: 15px;
+    top: 65px;
     left: 10px;
     display: flex;
     flex-direction: column;

--- a/hips_viewer/src/map.ts
+++ b/hips_viewer/src/map.ts
@@ -31,7 +31,7 @@ export async function createMap(mapId: string, tileUrl: string) {
   const ui = map.value.createLayer('ui')
   ui.createWidget('slider', { position: { right: 40, top: 40 } })
   colorLegend.value = ui.createWidget('colorLegend', {
-    position: { bottom: 10, left: 10, right: 10 },
+    position: { bottom: 50, left: 10, right: 10 },
     ticks: 10,
     width: '1000',
   })

--- a/hips_viewer/src/store.ts
+++ b/hips_viewer/src/store.ts
@@ -7,6 +7,9 @@ import type { FilterOption, UMAPTransform, UMAPResult } from './types'
 import { updateColorFunctions, updateOpacityFunctions } from './map'
 
 // Store variables
+export const images = ref()
+export const currentImage = ref()
+
 export const map = ref()
 export const maxZoom = ref()
 export const status = ref()
@@ -70,7 +73,63 @@ export const umapTransforms = ref<UMAPTransform[]>()
 export const umapTransformResults = ref<Record<number, UMAPResult[]>>({})
 export const umapSelectedResult = ref<UMAPResult>()
 
+function resetStore() {
+  // Reset everything except images and currentImage
+  map.value = undefined
+  maxZoom.value = undefined
+  status.value = undefined
+  statusProgress.value = 0
+  cells.value = undefined
+  cellColumns.value = undefined
+  cellVectorsProcessed.value = false
+  cellColors.value = undefined
+  clusterIds.value = {}
+  selectedCellIds.value = new Set()
+  cellFeature.value = undefined
+  pointFeature.value = undefined
+  annotationLayer.value = undefined
+  annotationMode.value = undefined
+  annotationBoolean.value = undefined
+  lastAnnotation.value = undefined
+  cellDrawerHeight.value = 0
+  cellDrawerResizing.value = false
+  tooltipEnabled.value = false
+  tooltipContent.value = undefined
+  tooltipPosition.value = undefined
+  unappliedColorChanges.value = false
+  histAttribute.value = 'classification'
+  showHistogram.value = false
+  histNumBuckets.value = 50
+  histCellIds.value = new Set()
+  histSelectionType.value = 'all'
+  histCellIdsDirty.value = false
+  histPrevViewport.value = undefined
+  histPrevSelectedCellIds.value = new Set()
+  histogramScale.value = 'linear'
+  histSelectedBars.value = new Set()
+  cellData.value = null
+  chartData.value = undefined
+  histColormapName.value = 'Set1'
+  colorLegend.value = undefined
+  selectedColor.value = '#000'
+  colorBy.value = 'classification'
+  colormapName.value = 'Set1'
+  attributeOptions.value = undefined
+  filterOptions.value = undefined
+  currentFilters.value = {}
+  hiddenFilters.value = new Set()
+  filterPopulation.value = 'all'
+  filterMatchCellIds.value = new Set()
+  umapTransforms.value = undefined
+  umapTransformResults.value = {}
+  umapSelectedResult.value = undefined
+}
+
 // Store watchers
+watch(currentImage, () => {
+  resetStore()
+})
+
 watch([selectedColor, colorBy, colormapName], () => {
   unappliedColorChanges.value = !!(
     selectedColor.value && colorBy.value && colormapName.value


### PR DESCRIPTION
Resolves #24 

Rather than offering a tab interface to switch between images, this PR replaces the tabs along the bottom of the toolbar with a selection on the right of the toolbar. The selected value is the first available image by default, but the user may specify a target image ID in the url to select that image by default. 

Example: `http://localhost:3000/images/1`

When the current image is changed, the store is reset. In order to prevent any aynchronous data processing for a previous image overwriting the state for a newly selected image, the selection is disabled during any processing.